### PR TITLE
Add PGGB's temporary directory parameter (`--pggb_temp_dir`)

### DIFF
--- a/cosigt_smk/workflow/rules/pggb.smk
+++ b/cosigt_smk/workflow/rules/pggb.smk
@@ -18,6 +18,7 @@ rule pggb_construct:
 		'benchmarks/{region}.pggb_construct.benchmark.txt'
 	params:
 		prefix=config['output'] + '/pggb/{region}',
+		temp_dir=config['pggb']['temp_dir'],
 		flags=config['pggb']['params']
 	shell:
 		'''
@@ -25,6 +26,7 @@ rule pggb_construct:
 			-i {input.fasta} \
 			-o {params.prefix} \
 			-t {threads} \
+			-D {params.temp_dir} \
 			{params.flags} \
 		&& mv {params.prefix}/*smooth.final.og {output}
 		'''

--- a/cosigt_smk/workflow/scripts/organize.py
+++ b/cosigt_smk/workflow/scripts/organize.py
@@ -83,6 +83,7 @@ def default_parameters(args):
 	d['pggb']['threads'] = args.pggb_threads
 	d['pggb']['mem_mb'] = args.pggb_memory
 	d['pggb']['time'] =  args.pggb_time
+	d['pggb']['temp_dir'] = args.temp_dir
 	d['pggb']['params'] =  args.pggb_params
 
 	#default
@@ -139,6 +140,7 @@ def main():
 	metrics.add_argument('--pggb_threads', help='# threads - pggb [24]',type=int, default=24)
 	metrics.add_argument('--pggb_time', help='max time (minutes) - pggb [35]',type=int, default=35)
 	metrics.add_argument('--pggb_memory', help='max memory (mb) - pggb [30000]',type=int, default=30000)
+	metrics.add_argument('--pggb_temp_dir', help='temporary directory - pggb [working directory]', type=str, default=os.getcwd())
 	metrics.add_argument('--pggb_params', help='additional parameters for pggb [-c 2]',type=str, default='-c 2')
 
 	args = parser.parse_args()

--- a/cosigt_smk/workflow/scripts/organize.py
+++ b/cosigt_smk/workflow/scripts/organize.py
@@ -83,7 +83,7 @@ def default_parameters(args):
 	d['pggb']['threads'] = args.pggb_threads
 	d['pggb']['mem_mb'] = args.pggb_memory
 	d['pggb']['time'] =  args.pggb_time
-	d['pggb']['temp_dir'] = args.temp_dir
+	d['pggb']['temp_dir'] = args.pggb_temp_dir
 	d['pggb']['params'] =  args.pggb_params
 
 	#default


### PR DESCRIPTION
This is an important parameter when `PGGB` (and then also `cosigt`) is run on HPC systems where it is necessary to specify as a working directory one mounted on high-speed drives (high I/O performance).