### PR TITLE
Manage `BEDPE` output (also for new `impg` compatibility)

### DIFF
--- a/cosigt_smk/workflow/rules/impg.smk
+++ b/cosigt_smk/workflow/rules/impg.smk
@@ -6,7 +6,7 @@ rule impg_project:
 		paf=config['paf'],
 		region=lambda wildcards: glob('resources/regions/{region}.bed'.format(region=wildcards.region))
 	output:
-		config['output'] + '/impg/{region}.bed'
+		config['output'] + '/impg/{region}.bedpe'
 	threads:
 		1
 	resources:
@@ -24,7 +24,6 @@ rule impg_project:
 		-p {input.paf} \
 		-b {input.region} \
 		-x | \
-		cut -f 1-3 | \
 		grep -v \
 		-f {params.exclude} > {output}
 		'''

--- a/cosigt_smk/workflow/rules/samtools.smk
+++ b/cosigt_smk/workflow/rules/samtools.smk
@@ -19,6 +19,9 @@ rule make_reference_bed:
 		'''
 		grep {params.path} \
 		{input} | \
+		cut -f 4-6 | \
+		bedtools sort -i - | \
+		bedtools merge -i - | \
 		sed 's/#/\t/' | \
 		rev | \
 		cut -f 1-3 | \


### PR DESCRIPTION
This allows a more generic workflow and makes `cosigt` compatible with the new (fixed) `impg`.