### PR TITLE
Manage node evidence in the coverage vectors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,9 +126,9 @@ RUN wget https://github.com/waveygang/wfmash/releases/download/v0.14.0/wfmash-v0
 ENV PATH /opt/wfmash-v0.14.0/build/bin:$PATH
 
 ##install gafpack
-RUN git clone https://github.com/ekg/gafpack.git \
+RUN git clone https://github.com/pangenome/gafpack.git \
 	&& cd gafpack \
-	&& git checkout cf2e96057c4efe86317caa990b53f1fc1fdc6367 \
+	&& git checkout 84eeab0d860245508729302c5b0ffa2ca159a350 \
 	&& cargo install --force --path . \
 	&& cp target/release/gafpack ../gafpack-tmp \
 	&& cd .. \

--- a/cosigt_smk/workflow/envs/gafpack.yaml
+++ b/cosigt_smk/workflow/envs/gafpack.yaml
@@ -2,4 +2,4 @@ channels:
  - conda-forge
  - bioconda
 dependencies:
- - gafpack=0.1.0
+ - gafpack=0.1.1

--- a/cosigt_smk/workflow/rules/gafpack.smk
+++ b/cosigt_smk/workflow/rules/gafpack.smk
@@ -1,6 +1,6 @@
 rule gafpack_coverage:
 	'''
-	https://github.com/ekg/gafpack
+	https://github.com/pangenome/gafpack
 	'''
 	input:
 		gfa=rules.odgi_view.output,

--- a/cosigt_smk/workflow/rules/gafpack.smk
+++ b/cosigt_smk/workflow/rules/gafpack.smk
@@ -23,5 +23,5 @@ rule gafpack_coverage:
 		gafpack \
 		-g {input.gfa} \
 		-a {input.gaf} \
-		--len-scale | gzip > {output}
+		--len-scale --weight-queries | gzip > {output}
 		'''


### PR DESCRIPTION
With the new `gafpack`, we can weight the node coverage based on the number of times the same query supports the same node. For example, if the same read maps to N pangenome sequences that match the same graph node, the coverage for that node is increased by
- +N by default
- +1/N if `--weight-queries` is specified in `gafpack`

The latter only slightly improves genotyping accuracy, but makes the pipeline more robust to multi-mapping reads.