### PR TITLE
Update gfainject and gafpack and compress gfainject output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,7 @@ ENV PATH /opt/wfmash-v0.14.0/build/bin:$PATH
 ##install gafpack
 RUN git clone https://github.com/pangenome/gafpack.git \
 	&& cd gafpack \
-	&& git checkout 84eeab0d860245508729302c5b0ffa2ca159a350 \
+	&& git checkout 6a0b7940d0ca4b552f5f80b3d1668ed0312080ad \
 	&& cargo install --force --path . \
 	&& cp target/release/gafpack ../gafpack-tmp \
 	&& cd .. \

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,7 @@ RUN git clone https://github.com/pangenome/gafpack.git \
 ##install gfainject
 RUN git clone https://github.com/AndreaGuarracino/gfainject \
 	&& cd gfainject \
-	&& git checkout cc4e2e070d1c0c883c2296024d5bb970f34820d8 \
+	&& git checkout b32b2a03b90d4c9ae935737b3bd7bd86ca8a2d78 \
 	&& cargo install --force --path . \
 	&& cp target/release/gfainject ../gfainject-tmp \
 	&& cd .. \

--- a/cosigt_smk/workflow/envs/gafpack.yaml
+++ b/cosigt_smk/workflow/envs/gafpack.yaml
@@ -2,4 +2,4 @@ channels:
  - conda-forge
  - bioconda
 dependencies:
- - gafpack=0.1.1
+ - gafpack=0.1.2

--- a/cosigt_smk/workflow/envs/gfainject.yaml
+++ b/cosigt_smk/workflow/envs/gfainject.yaml
@@ -2,4 +2,4 @@ channels:
  - conda-forge
  - bioconda
 dependencies:
-  - gfainject=0.1.0
+  - gfainject=0.2.0

--- a/cosigt_smk/workflow/rules/gafpack.smk
+++ b/cosigt_smk/workflow/rules/gafpack.smk
@@ -21,7 +21,7 @@ rule gafpack_coverage:
 	shell:
 		'''
 		gafpack \
-		-g {input.gfa} \
-		-a {input.gaf} \
+		--gfa {input.gfa} \
+		--gaf {input.gaf} \
 		--len-scale --weight-queries | gzip > {output}
 		'''

--- a/cosigt_smk/workflow/rules/gfainject.smk
+++ b/cosigt_smk/workflow/rules/gfainject.smk
@@ -6,7 +6,7 @@ rule gfainject_inject:
 		gfa=rules.odgi_view.output,
 		bam=rules.bwamem2_mem_samtools_sort.output
 	output:
-		config['output'] + '/gfainject/{sample}/{region}.gaf'
+		config['output'] + '/gfainject/{sample}/{region}.gaf.gz'
 	threads:
 		1
 	resources:
@@ -22,5 +22,5 @@ rule gfainject_inject:
 		'''
 		gfainject \
 		--gfa {input.gfa} \
-		--bam {input.bam} > {output}
+		--bam {input.bam} | gzip > {output}
 		'''


### PR DESCRIPTION
This integrates https://github.com/AndreaGuarracino/gfainject/pull/6 (there were 2 little issues) and https://github.com/pangenome/gafpack/pull/5 (now it supports compressed GAF input files).