### PR TITLE
Update `odgi`, `smoothxg`, `pggb`, and emit all pairs in `odgi similarity`

### DIFF
--- a/cosigt_smk/workflow/envs/odgi.yaml
+++ b/cosigt_smk/workflow/envs/odgi.yaml
@@ -2,4 +2,4 @@ channels:
  - conda-forge
  - bioconda
 dependencies:
- - odgi=0.9.0
+ - odgi=0.9.2

--- a/cosigt_smk/workflow/envs/pggb.yaml
+++ b/cosigt_smk/workflow/envs/pggb.yaml
@@ -2,4 +2,4 @@ channels:
  - conda-forge
  - bioconda
 dependencies:
- - pggb=0.7.3
+ - pggb=0.7.4

--- a/cosigt_smk/workflow/rules/benchmark.smk
+++ b/cosigt_smk/workflow/rules/benchmark.smk
@@ -46,7 +46,7 @@ rule odgi_flip_pggb_graph:
 		mem_mb=lambda wildcards, attempt: attempt * config['default_high']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['default_small']['time']
 	container:
-		'docker://pangenome/odgi:1738101065'
+		'docker://pangenome/odgi:1745375412'
 	conda:
 		'../envs/odgi.yaml'
 	params:
@@ -73,7 +73,7 @@ rule odgi_og_to_fasta:
 		mem_mb=lambda wildcards, attempt: attempt * config['default_high']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['default_small']['time']
 	container:
-		'docker://pangenome/odgi:1738101065'
+		'docker://pangenome/odgi:1745375412'
 	conda:
 		'../envs/odgi.yaml'
 	shell:

--- a/cosigt_smk/workflow/rules/odgi.smk
+++ b/cosigt_smk/workflow/rules/odgi.smk
@@ -127,6 +127,7 @@ rule odgi_dissimilarity_submasks:
 		odgi similarity \
 		-i {input.og} \
 		-m {input.mask} \
+		--all \
 		--distances > {output}
 		'''
 
@@ -202,6 +203,7 @@ rule odgi_dissimilarity:
 		odgi similarity \
 		-i {input.og} \
 		-m {input.mask} \
+		--all \
 		--distances > {output}
 		'''
 

--- a/cosigt_smk/workflow/rules/odgi.smk
+++ b/cosigt_smk/workflow/rules/odgi.smk
@@ -12,7 +12,7 @@ rule odgi_view:
 		mem_mb=lambda wildcards, attempt: attempt * config['default_mid']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['default_small']['time']
 	container:
-		'docker://pangenome/odgi:1738101065'
+		'docker://pangenome/odgi:1745375412'
 	conda:
 		'../envs/odgi.yaml'
 	benchmark:
@@ -38,7 +38,7 @@ rule odgi_paths_matrix:
 		mem_mb=lambda wildcards, attempt: attempt * config['default_mid']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['default_small']['time']
 	container:
-		'docker://pangenome/odgi:1738101065'
+		'docker://pangenome/odgi:1745375412'
 	conda:
 		'../envs/odgi.yaml'
 	benchmark:
@@ -117,7 +117,7 @@ rule odgi_dissimilarity_submasks:
 		mem_mb=lambda wildcards, attempt: attempt * config['default_mid']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['default_small']['time']
 	container:
-		'docker://pangenome/odgi:1738101065'
+		'docker://pangenome/odgi:1745375412'
 	conda:
 		'../envs/odgi.yaml'
 	benchmark:
@@ -193,7 +193,7 @@ rule odgi_dissimilarity:
 		mem_mb=lambda wildcards, attempt: attempt * config['default_mid']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['default_small']['time']
 	container:
-		'docker://pangenome/odgi:1738101065'
+		'docker://pangenome/odgi:1745375412'
 	conda:
 		'../envs/odgi.yaml'
 	benchmark:
@@ -254,7 +254,7 @@ rule odgi_viz:
 		mem_mb=lambda wildcards, attempt: attempt * config['default_mid']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['default_small']['time']
 	container:
-		'docker://pangenome/odgi:1738101065'
+		'docker://pangenome/odgi:1745375412'
 	conda:
 		'../envs/odgi.yaml'
 	benchmark:
@@ -342,7 +342,7 @@ rule odgi_procbed:
 		mem_mb=lambda wildcards, attempt: attempt * config['default_mid']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['default_small']['time']
 	container:
-		'docker://pangenome/odgi:1738101065'
+		'docker://pangenome/odgi:1745375412'
 	conda:
 		'../envs/odgi.yaml'
 	benchmark:
@@ -409,7 +409,7 @@ rule odgi_inject:
 		mem_mb=lambda wildcards, attempt: attempt * config['default_small']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['default_small']['time']
 	container:
-		'docker://pangenome/odgi:1738101065'
+		'docker://pangenome/odgi:1745375412'
 	conda:
 		'../envs/odgi.yaml'
 	benchmark:
@@ -437,7 +437,7 @@ rule odgi_flip:
 		mem_mb=lambda wildcards, attempt: attempt * config['default_mid']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['default_small']['time']
 	container:
-		'docker://pangenome/odgi:1738101065'
+		'docker://pangenome/odgi:1745375412'
 	conda:
 		'../envs/odgi.yaml'
 	benchmark:
@@ -465,7 +465,7 @@ rule odgi_untangle:
 		mem_mb=lambda wildcards, attempt: attempt * config['default_mid']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['default_small']['time']
 	container:
-		'docker://pangenome/odgi:1738101065'
+		'docker://pangenome/odgi:1745375412'
 	conda:
 		'../envs/odgi.yaml'
 	benchmark:

--- a/cosigt_smk/workflow/rules/pggb.smk
+++ b/cosigt_smk/workflow/rules/pggb.smk
@@ -13,7 +13,7 @@ rule pggb_construct:
 		mem_mb=lambda wildcards, attempt: attempt * config['pggb']['mem_mb'],
 		time=lambda wildcards, attempt: attempt * config['pggb']['time']
 	container:
-		'docker://ghcr.io/pangenome/pggb:20250410205145cfcfba'
+		'docker://ghcr.io/pangenome/pggb:20250423145743e25486'
 	conda:
 		'../envs/pggb.yaml'
 	benchmark:


### PR DESCRIPTION
Emitting all pairs with `odgi similarity` avoids errors during the benchmark. Singleton paths (not aligned to anything else) were leading to missing pairs (missing similarity or distances) and then errors during the benchmarking.

The latest PGGB runs two rounds of `smoothxg`. This saves a nice piece of computation without really affecting the final graphs.